### PR TITLE
Replaced / removed references to AWS Lambda Extensions being public p…

### DIFF
--- a/content/50_Instrumenting_Lambda_Functions/51_Python/1_Add_Instrumentation.md
+++ b/content/50_Instrumenting_Lambda_Functions/51_Python/1_Add_Instrumentation.md
@@ -55,7 +55,7 @@ Save your changes, and now we will add the AppDynamics AWS Lambda Extension to e
       - arn:aws:lambda:${opt:region, self:provider.region}:716333212585:layer:appdynamics-lambda-extension:10
 ```
 
-The AppDynamics AWS Lambda Extension is published as a Lambda layer, and it takes advantage of the AWS Lambda Extensions API (currently under public preview). In this snippet, we're telling our deployment to base the region of our Lambda layer on the region where our Lambdas are deployed. The resulting change should look like the screenshot below.
+The AppDynamics AWS Lambda Extension is published as a Lambda layer, and it takes advantage of the AWS Lambda Extensions API. In this snippet, we're telling our deployment to base the region of our Lambda layer on the region where our Lambdas are deployed. The resulting change should look like the screenshot below.
 
 ![image](/images/instrumenting_lambda_functions/python/Serverless_Lambda_Layers.png)
 

--- a/content/50_Instrumenting_Lambda_Functions/51_Python/_index.md
+++ b/content/50_Instrumenting_Lambda_Functions/51_Python/_index.md
@@ -6,7 +6,7 @@ weight = 51
 
 ## Objective
 
-In this section of the workshop, we are going to add AppDynamics instrumentation to a set of AWS Lambda functions written in Python. We will walk through the steps of configuring the Lambda functions to use the AppDynamics [AWS Lambda Extension](https://aws.amazon.com/blogs/compute/introducing-aws-lambda-extensions-in-preview/). Finally, we will add in custom code to show exit calls to AWS resources that are not automatically detected.
+In this section of the workshop, we are going to add AppDynamics instrumentation to a set of AWS Lambda functions written in Python. We will walk through the steps of configuring the Lambda functions to use the AppDynamics [AWS Lambda Extension](https://aws.amazon.com/blogs/aws/getting-started-with-using-your-favorite-operational-tools-on-aws-lambda-extensions-are-now-generally-available/). Finally, we will add in custom code to show exit calls to AWS resources that are not automatically detected.
 
 ## Introduction to AppDynamics Serverless APM for AWS Lambda -- Python
 

--- a/content/50_Instrumenting_Lambda_Functions/52_NodeJS/1_Add_Instrumentation.md
+++ b/content/50_Instrumenting_Lambda_Functions/52_NodeJS/1_Add_Instrumentation.md
@@ -49,7 +49,7 @@ Save your changes, and now we will add the AppDynamics AWS Lambda Extension to e
       - arn:aws:lambda:${opt:region, self:provider.region}:716333212585:layer:appdynamics-lambda-extension:10
 ```
 
-The AppDynamics AWS Lambda Extension is published as a Lambda layer, and it takes advantage of the AWS Lambda Extensions API (currently under public preview). In this snippet, we're telling our deployment to base the region of our Lambda layer on the region where our Lambdas are deployed. The resulting change should look like the screenshot below.
+The AppDynamics AWS Lambda Extension is published as a Lambda layer, and it takes advantage of the AWS Lambda Extensions API. In this snippet, we're telling our deployment to base the region of our Lambda layer on the region where our Lambdas are deployed. The resulting change should look like the screenshot below.
 
 ![image](/images/instrumenting_lambda_functions/node/Serverless_Lambda_Layers.png)
 

--- a/content/50_Instrumenting_Lambda_Functions/_index.md
+++ b/content/50_Instrumenting_Lambda_Functions/_index.md
@@ -10,7 +10,7 @@ In our sandbox environment, the Lambda functions being utilized were written by 
 
 AppDynamics supports monitoring AWS Lambda functions written in Python (version 3.6 and greater), NodeJS (version 10.x and greater), and Java (version 1.8 and greater). Instrumentation is accomplished through using a tracer module that captures relevant data. The tracer module does not depend on any other AWS services. The tracer captures performance information for each invocation of the Lambda function and transmits it asynchronously to AppDynamics.
 
-For functions written in Python and NodeJS, AppDynamics has integrated with [AWS Lambda Extensions](https://aws.amazon.com/blogs/compute/introducing-aws-lambda-extensions-in-preview/) feature to create a Lambda Layer to automatically handle instrumentation.
+For functions written in Python and NodeJS, AppDynamics has integrated with [AWS Lambda Extensions](https://aws.amazon.com/blogs/aws/getting-started-with-using-your-favorite-operational-tools-on-aws-lambda-extensions-are-now-generally-available/) feature to create a Lambda Layer to automatically handle instrumentation.
 ![image](/images/instrumenting_lambda_functions/Node_Python_Lambda_Layer.png)
 
 For Java-based Lambda functions, the tracer is embedded as an SDK directly within the function.


### PR DESCRIPTION
Removed references to the AWS Lambda Extensions API being in public preview. Replaced public preview links with GA announcement links.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
